### PR TITLE
Little problem with SVA assertion printer

### DIFF
--- a/src/exp/src/visitors/PrinterVisitor.cc
+++ b/src/exp/src/visitors/PrinterVisitor.cc
@@ -294,7 +294,7 @@ bool isBinaryRightAssociative(ope::temporalOpe op) {
     if (clc::svaAssert &&                                            \
         _printMode != PrintMode::ShowOnlyPermuationPlaceholders) {   \
       std::string assert =                                           \
-          "assert property ((@posedge " + clc::clk + ") ";           \
+          "assert property (@(posedge " + clc::clk + ") ";           \
       _ss << selCol(assert, chooseTemporalOpColor(                   \
                                 assert, ope::temporalOpe::NODE));    \
     } else {                                                         \


### PR DESCRIPTION
Hey,

I was playing a bit with your tool, and it is very interesting! 

I think I encountered a minor bug in the way the SVA assertions are printed. Currently, in your main, the SVA assertions are printed as:

```verilog
assert property ((@posedge clk) prop)
```

Whereas, to stay in line with the standard and make it more easily integrable into a workflow, I think they would be better printed as:

```verilog
assert property (@(posedge clk) prop)
```

I made this (very minor) change on a fork of your repository, and you can integrate it if you want. I also think that some modifications might be needed in the parser in `src/antlr4/temporalParser/grammarTemporal/temporal.g4` that seems to suffer from the same problem, but it is less critical in my use case, so I haven't made the modification.

Best,

Félix